### PR TITLE
feat: add Ruby Rails SDK package

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,19 +12,29 @@ Official SDKs and middleware for The Passport for AI Agents.
 - **SDK**: [aporthq-sdk-python](sdk/python/) - Core Python SDK  
 - **Middleware**: [agent-passport-middleware-fastapi](middleware/fastapi/) - FastAPI middleware
 
+### Ruby
+- **SDK**: [aporthq-sdk-ruby](sdk/ruby/) - Core Ruby SDK
+- **Middleware**: [Rack/Rails middleware](sdk/ruby/) - Rails verification middleware and helpers
+
 ## Quick Start
 
 ### Node.js
-\`\`\`bash
+```bash
 npm install @aporthq/sdk-node
 npm install @aporthq/middleware-express
-\`\`\`
+```
 
 ### Python
-\`\`\`bash
+```bash
 pip install aporthq-sdk-python
 pip install agent-passport-middleware-fastapi
-\`\`\`
+```
+
+### Ruby
+```bash
+gem install aporthq-sdk-ruby
+bin/rails generate aport:install
+```
 
 ## Documentation
 

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -14,6 +14,11 @@ This directory contains SDKs and middleware for integrating with The Passport fo
 - **Location**: `./python/`
 - **Description**: Python thin client for policy verification and passport views (async aiohttp)
 
+### Ruby SDK
+- **Package**: `aporthq-sdk-ruby`
+- **Location**: `./ruby/`
+- **Description**: Ruby thin client for policy verification with Rack/Rails middleware, helpers, and generator
+
 ### Express.js Middleware
 - **Package**: `@aporthq/middleware-express`
 - **Location**: `../middleware/express/`
@@ -76,6 +81,25 @@ async def main():
 asyncio.run(main())
 ```
 
+### Ruby
+
+```bash
+gem install aporthq-sdk-ruby
+```
+
+```ruby
+require "aport/sdk"
+
+client = APort::SDK::Client.new(api_key: ENV["AGENT_PASSPORT_API_KEY"])
+decision = client.verify_policy(
+  agent_id: "your-agent-id",
+  policy_id: "finance.payment.refund.v1",
+  context: { amount: 1000, currency: "USD", order_id: "order_123" },
+  idempotency_key: "refund-order-123"
+)
+puts "Allowed: #{decision["decision_id"]}" if decision["allow"]
+```
+
 ### Express.js Middleware
 
 ```bash
@@ -114,6 +138,15 @@ app.add_middleware(
 @app.post("/api/refunds")
 async def get_data(request: Request):
     return {"agent_id": request.state.agent.agent_id}
+```
+
+### Rails Middleware
+
+```ruby
+Rails.application.config.middleware.use(
+  APort::SDK::Middleware,
+  policy_id: "finance.payment.refund.v1"
+)
 ```
 
 ## Supported Policies
@@ -216,6 +249,10 @@ npm test
 cd python/
 pip install -e ".[dev]"
 pytest
+
+# Ruby SDK
+cd ruby/
+bundle exec rake test
 ```
 
 ### Building Middleware
@@ -238,6 +275,7 @@ pytest
 - [Transport Profile Specification](../spec/transport-profile.md) - Complete transport specification
 - [Node.js SDK Documentation](./node/README.md) - Node.js SDK documentation
 - [Python SDK Documentation](./python/README.md) - Python SDK documentation
+- [Ruby SDK Documentation](./ruby/README.md) - Ruby SDK and Rails middleware documentation
 - [Express.js Middleware Documentation](../middleware/express/README.md) - Express.js middleware documentation
 - [FastAPI Middleware Documentation](../middleware/fastapi/README.md) - FastAPI middleware documentation
 

--- a/sdk/ruby/Gemfile
+++ b/sdk/ruby/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gemspec

--- a/sdk/ruby/LICENSE
+++ b/sdk/ruby/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) APort
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/sdk/ruby/README.md
+++ b/sdk/ruby/README.md
@@ -1,0 +1,88 @@
+# APort Ruby SDK
+
+Ruby and Rails package for APort policy verification.
+
+## Install
+
+```ruby
+gem "aporthq-sdk-ruby"
+```
+
+```bash
+bundle install
+bin/rails generate aport:install
+```
+
+## Client
+
+```ruby
+require "aport/sdk"
+
+client = APort::SDK::Client.new(
+  base_url: "https://api.aport.io",
+  api_key: ENV["AGENT_PASSPORT_API_KEY"],
+  timeout: 0.8
+)
+
+decision = client.verify_policy(
+  agent_id: "agent_123",
+  policy_id: "finance.payment.refund.v1",
+  context: {
+    amount: 1000,
+    currency: "USD",
+    order_id: "order_123"
+  },
+  idempotency_key: "refund-order-123"
+)
+
+puts decision["decision_id"] if decision["allow"]
+```
+
+## Rails Middleware
+
+Add middleware in `config/initializers/aport.rb`:
+
+```ruby
+Rails.application.config.middleware.use(
+  APort::SDK::Middleware,
+  policy_id: "finance.payment.refund.v1"
+)
+```
+
+The middleware reads `X-Agent-Passport-Id`, `X-Agent-Id`, or `body.passport.agent_id`, sends request context to APort, and stores these values in the Rack/Rails environment:
+
+- `env["aport.agent_id"]`
+- `env["aport.decision"]`
+
+Requests with `allow=false` return `403` with the APort denial reasons.
+
+## Controller Helpers
+
+Rails controllers get:
+
+```ruby
+aport_agent_id
+aport_decision
+verify_aport_policy!(
+  "finance.payment.refund.v1",
+  context: { amount: 1000, currency: "USD" }
+)
+```
+
+## Inline Passport and Policy
+
+The middleware and client support local passport and inline policy evaluation:
+
+```ruby
+client.verify_policy_with_policy_in_body(
+  agent_or_passport: { "agent_id" => "agent_123", "claims" => { "role" => "buyer" } },
+  policy: { "id" => "custom.policy.v1", "requires_capabilities" => ["payments.charge"] },
+  context: { amount: 1000 }
+)
+```
+
+## Development
+
+```bash
+bundle exec rake test
+```

--- a/sdk/ruby/Rakefile
+++ b/sdk/ruby/Rakefile
@@ -1,0 +1,8 @@
+require "rake/testtask"
+
+Rake::TestTask.new do |task|
+  task.libs << "test"
+  task.pattern = "test/**/*_test.rb"
+end
+
+task default: :test

--- a/sdk/ruby/aporthq-sdk-ruby.gemspec
+++ b/sdk/ruby/aporthq-sdk-ruby.gemspec
@@ -1,0 +1,18 @@
+Gem::Specification.new do |spec|
+  spec.name = "aporthq-sdk-ruby"
+  spec.version = "0.1.0"
+  spec.authors = ["APort"]
+  spec.email = ["support@aport.io"]
+
+  spec.summary = "Ruby and Rails SDK for APort policy verification"
+  spec.description = "Thin APort API client with Rack/Rails middleware, helpers, and install generator."
+  spec.homepage = "https://aport.io"
+  spec.license = "MIT"
+
+  spec.required_ruby_version = ">= 2.6.0"
+  spec.files = Dir["lib/**/*", "README.md", "LICENSE"]
+  spec.require_paths = ["lib"]
+
+  spec.add_development_dependency "rake", "~> 12.0"
+  spec.add_development_dependency "minitest", "~> 5.0"
+end

--- a/sdk/ruby/lib/aport/sdk.rb
+++ b/sdk/ruby/lib/aport/sdk.rb
@@ -1,0 +1,46 @@
+require "aport/sdk/version"
+require "aport/sdk/error"
+require "aport/sdk/client"
+require "aport/sdk/middleware"
+require "aport/sdk/policy_verifier"
+require "aport/sdk/rails" if defined?(Rails)
+
+module APort
+  module SDK
+    DEFAULT_BASE_URL = "https://api.aport.io"
+    DEFAULT_TIMEOUT = 0.8
+
+    class << self
+      attr_writer :client
+
+      def client
+        @client ||= Client.new
+      end
+
+      def configure
+        yield(configuration)
+        @client = Client.new(
+          base_url: configuration.base_url,
+          api_key: configuration.api_key,
+          timeout: configuration.timeout
+        )
+      end
+
+      def configuration
+        @configuration ||= Configuration.new
+      end
+    end
+
+    class Configuration
+      attr_accessor :base_url, :api_key, :timeout
+
+      def initialize
+        @base_url = ENV.fetch("AGENT_PASSPORT_BASE_URL", DEFAULT_BASE_URL)
+        @api_key = ENV["AGENT_PASSPORT_API_KEY"]
+        @timeout = DEFAULT_TIMEOUT
+      end
+    end
+  end
+end
+
+require "aport/sdk/railtie" if defined?(Rails::Railtie)

--- a/sdk/ruby/lib/aport/sdk/client.rb
+++ b/sdk/ruby/lib/aport/sdk/client.rb
@@ -1,0 +1,196 @@
+require "json"
+require "net/http"
+require "uri"
+
+module APort
+  module SDK
+    class Client
+      USER_AGENT = "aport-sdk-ruby/0.1.0"
+
+      def initialize(base_url: ENV.fetch("AGENT_PASSPORT_BASE_URL", DEFAULT_BASE_URL), api_key: ENV["AGENT_PASSPORT_API_KEY"], timeout: DEFAULT_TIMEOUT, http: nil)
+        @base_url = base_url.to_s.sub(%r{/+\z}, "")
+        @api_key = api_key
+        @timeout = timeout
+        @http = http
+        @jwks_cache = nil
+        @jwks_cache_expires_at = nil
+      end
+
+      def verify_policy(agent_id:, policy_id:, context: {}, idempotency_key: nil, passport: nil, policy: nil)
+        path = policy ? "/api/verify/policy/IN_BODY" : "/api/verify/policy/#{escape_path(policy_id)}"
+        body = build_policy_request_body(
+          agent_id: agent_id,
+          policy_id: policy_id,
+          context: context,
+          idempotency_key: idempotency_key,
+          passport: passport,
+          policy: policy
+        )
+        normalize_decision(post(path, body, idempotency_key: idempotency_key))
+      end
+
+      def verify_policy_with_passport(passport:, policy_id:, context: {}, idempotency_key: nil)
+        verify_policy(
+          agent_id: passport.fetch("agent_id"),
+          policy_id: policy_id,
+          context: context,
+          idempotency_key: idempotency_key,
+          passport: passport
+        )
+      end
+
+      def verify_policy_with_policy_in_body(agent_or_passport:, policy:, context: {}, idempotency_key: nil)
+        agent_id = agent_or_passport.is_a?(Hash) ? agent_or_passport.fetch("agent_id") : agent_or_passport
+        verify_policy(
+          agent_id: agent_id,
+          policy_id: policy.fetch("id"),
+          context: context,
+          idempotency_key: idempotency_key,
+          passport: agent_or_passport.is_a?(Hash) ? agent_or_passport : nil,
+          policy: policy
+        )
+      end
+
+      def get_decision_token(agent_id:, policy_id:, context: {})
+        response = post("/api/verify/token/#{escape_path(policy_id)}", {
+          "agent_id" => agent_id,
+          "context" => stringify_keys(context)
+        })
+        response.fetch("token")
+      end
+
+      def validate_decision_token(token:)
+        normalize_decision(post("/api/verify/token/validate", { "token" => token }))
+      end
+
+      def validate_decision_token_local(token:)
+        get_jwks
+        validate_decision_token(token: token)
+      rescue Error => error
+        raise Error.new(
+          status: 401,
+          reasons: [{ "code" => "INVALID_TOKEN", "message" => "Token validation failed" }],
+          raw_response: error.raw_response
+        )
+      end
+
+      def get_passport_view(agent_id:)
+        get("/api/passports/#{escape_path(agent_id)}/verify_view")
+      end
+
+      def get_jwks
+        if @jwks_cache && @jwks_cache_expires_at && Time.now < @jwks_cache_expires_at
+          return @jwks_cache
+        end
+
+        @jwks_cache = get("/jwks.json")
+        @jwks_cache_expires_at = Time.now + 300
+        @jwks_cache
+      rescue Error => error
+        raise Error.new(
+          status: 500,
+          reasons: [{ "code" => "JWKS_FETCH_FAILED", "message" => "Failed to fetch JWKS" }],
+          raw_response: error.raw_response
+        )
+      end
+
+      private
+
+      def get(path)
+        request(Net::HTTP::Get, path)
+      end
+
+      def post(path, body, idempotency_key: nil)
+        request(Net::HTTP::Post, path, body: body, idempotency_key: idempotency_key)
+      end
+
+      def request(klass, path, body: nil, idempotency_key: nil)
+        uri = URI.parse("#{@base_url}#{path}")
+        request = klass.new(uri)
+        request["Accept"] = "application/json"
+        request["User-Agent"] = USER_AGENT
+        request["Authorization"] = "Bearer #{@api_key}" if @api_key && !@api_key.empty?
+        request["Idempotency-Key"] = idempotency_key if idempotency_key
+
+        if body
+          request["Content-Type"] = "application/json"
+          request.body = JSON.generate(body)
+        end
+
+        response = perform_request(uri, request)
+        parsed = parse_json(response.body)
+        server_timing = response["server-timing"]
+
+        unless response.code.to_i.between?(200, 299)
+          raise Error.new(
+            status: response.code.to_i,
+            reasons: parsed["reasons"],
+            decision_id: parsed["decision_id"],
+            server_timing: server_timing,
+            raw_response: response.body
+          )
+        end
+
+        parsed["_meta"] = { "serverTiming" => server_timing } if server_timing
+        parsed
+      rescue Timeout::Error => error
+        raise Error.new(status: 408, reasons: [{ "code" => "TIMEOUT", "message" => error.message }])
+      rescue SystemCallError, SocketError => error
+        raise Error.new(status: 0, reasons: [{ "code" => "NETWORK_ERROR", "message" => error.message }])
+      end
+
+      def perform_request(uri, request)
+        return @http.request(uri, request) if @http
+
+        Net::HTTP.start(
+          uri.host,
+          uri.port,
+          use_ssl: uri.scheme == "https",
+          open_timeout: @timeout,
+          read_timeout: @timeout
+        ) do |http|
+          http.request(request)
+        end
+      end
+
+      def build_policy_request_body(agent_id:, policy_id:, context:, idempotency_key:, passport:, policy:)
+        request_context = {}
+        request_context["agent_id"] = agent_id if agent_id
+        request_context["policy_id"] = policy_id if policy_id
+        request_context["idempotency_key"] = idempotency_key if idempotency_key
+        stringify_keys(context).each { |key, value| request_context[key] = value }
+
+        body = { "context" => request_context }
+        body["passport"] = passport if passport
+        body["policy"] = policy if policy
+        body
+      end
+
+      def normalize_decision(response)
+        decision = response["decision"] || response
+        if response["_meta"] && !decision["_meta"]
+          decision["_meta"] = response["_meta"]
+        end
+        decision
+      end
+
+      def stringify_keys(hash)
+        (hash || {}).each_with_object({}) do |(key, value), output|
+          output[key.to_s] = value
+        end
+      end
+
+      def parse_json(body)
+        return {} if body.nil? || body.empty?
+
+        JSON.parse(body)
+      rescue JSON::ParserError
+        {}
+      end
+
+      def escape_path(value)
+        URI.encode_www_form_component(value.to_s)
+      end
+    end
+  end
+end

--- a/sdk/ruby/lib/aport/sdk/error.rb
+++ b/sdk/ruby/lib/aport/sdk/error.rb
@@ -1,0 +1,29 @@
+module APort
+  module SDK
+    class Error < StandardError
+      attr_reader :status, :reasons, :decision_id, :server_timing, :raw_response
+
+      def initialize(status:, reasons: nil, decision_id: nil, server_timing: nil, raw_response: nil)
+        @status = status
+        @reasons = reasons || []
+        @decision_id = decision_id
+        @server_timing = server_timing
+        @raw_response = raw_response
+        super(build_message)
+      end
+
+      private
+
+      def build_message
+        return "APort request failed: #{status}" if reasons.empty?
+
+        messages = reasons.map { |reason| reason["message"] || reason[:message] || reason["code"] || reason[:code] }.compact
+        return "APort request failed: #{status}" if messages.empty?
+
+        "APort request failed: #{status} #{messages.join(", ")}"
+      end
+    end
+
+    AportError = Error
+  end
+end

--- a/sdk/ruby/lib/aport/sdk/middleware.rb
+++ b/sdk/ruby/lib/aport/sdk/middleware.rb
@@ -1,0 +1,115 @@
+require "json"
+require "stringio"
+
+module APort
+  module SDK
+    class Middleware
+      DEFAULT_SKIP_PATHS = ["/health", "/metrics", "/status"].freeze
+
+      def initialize(app, client: SDK.client, policy_id: nil, agent_id: nil, fail_closed: true, skip_paths: DEFAULT_SKIP_PATHS)
+        @app = app
+        @client = client
+        @policy_id = policy_id
+        @agent_id = agent_id
+        @fail_closed = fail_closed
+        @skip_paths = skip_paths
+      end
+
+      def call(env)
+        return @app.call(env) if skip?(env)
+
+        body = json_body(env)
+        passport = body["passport"].is_a?(Hash) ? body["passport"] : nil
+        policy = body["policy"].is_a?(Hash) ? body["policy"] : nil
+        agent_id = @agent_id || passport && passport["agent_id"] || env["HTTP_X_AGENT_PASSPORT_ID"] || env["HTTP_X_AGENT_ID"]
+
+        unless agent_id || passport
+          return json_response(401, "missing_agent_id", "Agent ID is required. Provide X-Agent-Passport-Id, X-Agent-Id, or body.passport.") if @fail_closed
+
+          return @app.call(env)
+        end
+
+        context = body.reject { |key, _value| key == "passport" || key == "policy" }
+        decision = verify(agent_id, passport, policy, context, env["HTTP_IDEMPOTENCY_KEY"])
+        if decision && decision["allow"] == false
+          return json_response(
+            403,
+            "policy_violation",
+            "Policy violation",
+            "agent_id" => agent_id,
+            "policy_id" => @policy_id || policy && policy["id"],
+            "decision_id" => decision["decision_id"],
+            "reasons" => decision["reasons"]
+          )
+        end
+
+        env["aport.agent_id"] = agent_id || passport["agent_id"]
+        env["aport.decision"] = decision if decision
+        @app.call(env)
+      rescue Error => error
+        json_response(error.status.zero? ? 502 : error.status, "api_error", error.message, "reasons" => error.reasons)
+      end
+
+      private
+
+      def verify(agent_id, passport, policy, context, idempotency_key)
+        if policy && passport
+          @client.verify_policy_with_policy_in_body(
+            agent_or_passport: passport,
+            policy: policy,
+            context: context,
+            idempotency_key: idempotency_key
+          )
+        elsif policy
+          @client.verify_policy_with_policy_in_body(
+            agent_or_passport: agent_id,
+            policy: policy,
+            context: context,
+            idempotency_key: idempotency_key
+          )
+        elsif passport
+          @client.verify_policy_with_passport(
+            passport: passport,
+            policy_id: @policy_id,
+            context: context,
+            idempotency_key: idempotency_key
+          )
+        elsif @policy_id
+          @client.verify_policy(
+            agent_id: agent_id,
+            policy_id: @policy_id,
+            context: context,
+            idempotency_key: idempotency_key
+          )
+        else
+          @client.get_passport_view(agent_id: agent_id)
+          nil
+        end
+      end
+
+      def skip?(env)
+        path = env["PATH_INFO"] || env["REQUEST_PATH"] || ""
+        @skip_paths.any? { |skip_path| path.start_with?(skip_path) }
+      end
+
+      def json_body(env)
+        input = env["rack.input"]
+        return {} unless input
+
+        raw = input.read
+        input.rewind if input.respond_to?(:rewind)
+        return {} if raw.nil? || raw.empty?
+        return {} unless (env["CONTENT_TYPE"] || "").include?("json")
+
+        JSON.parse(raw)
+      rescue JSON::ParserError
+        {}
+      end
+
+      def json_response(status, error, message, extra = {})
+        body = JSON.generate({ "error" => error, "message" => message }.merge(extra.compact))
+        [status, { "Content-Type" => "application/json" }, [body]]
+      end
+    end
+  end
+end

--- a/sdk/ruby/lib/aport/sdk/policy_verifier.rb
+++ b/sdk/ruby/lib/aport/sdk/policy_verifier.rb
@@ -1,0 +1,36 @@
+module APort
+  module SDK
+    class PolicyVerifier
+      def initialize(client = SDK.client)
+        @client = client
+      end
+
+      def verify_refund(agent_id:, context:, idempotency_key: nil)
+        @client.verify_policy(
+          agent_id: agent_id,
+          policy_id: "finance.payment.refund.v1",
+          context: context,
+          idempotency_key: idempotency_key
+        )
+      end
+
+      def verify_release(agent_id:, context:, idempotency_key: nil)
+        @client.verify_policy(
+          agent_id: agent_id,
+          policy_id: "code.release.publish.v1",
+          context: context,
+          idempotency_key: idempotency_key
+        )
+      end
+
+      def verify_data_export(agent_id:, context:, idempotency_key: nil)
+        @client.verify_policy(
+          agent_id: agent_id,
+          policy_id: "data.export.create.v1",
+          context: context,
+          idempotency_key: idempotency_key
+        )
+      end
+    end
+  end
+end

--- a/sdk/ruby/lib/aport/sdk/rails.rb
+++ b/sdk/ruby/lib/aport/sdk/rails.rb
@@ -1,0 +1,28 @@
+module APort
+  module SDK
+    module Rails
+      module ControllerHelpers
+        def aport_agent_id
+          request.env["aport.agent_id"]
+        end
+
+        def aport_decision
+          request.env["aport.decision"]
+        end
+
+        def verify_aport_policy!(policy_id, context: {}, agent_id: nil, idempotency_key: nil)
+          resolved_agent_id = agent_id || aport_agent_id || request.headers["X-Agent-Passport-Id"] || request.headers["X-Agent-Id"]
+          SDK.client.verify_policy(
+            agent_id: resolved_agent_id,
+            policy_id: policy_id,
+            context: context,
+            idempotency_key: idempotency_key
+          ).tap do |decision|
+            request.env["aport.decision"] = decision
+            raise Error.new(status: 403, reasons: decision["reasons"], decision_id: decision["decision_id"]) unless decision["allow"]
+          end
+        end
+      end
+    end
+  end
+end

--- a/sdk/ruby/lib/aport/sdk/railtie.rb
+++ b/sdk/ruby/lib/aport/sdk/railtie.rb
@@ -1,0 +1,18 @@
+module APort
+  module SDK
+    class Railtie < ::Rails::Railtie
+      initializer "aport.sdk.configure" do
+        APort::SDK.configure do |config|
+          config.base_url = ENV.fetch("AGENT_PASSPORT_BASE_URL", DEFAULT_BASE_URL)
+          config.api_key = ENV["AGENT_PASSPORT_API_KEY"]
+        end
+      end
+
+      initializer "aport.sdk.controller_helpers" do
+        ActiveSupport.on_load(:action_controller) do
+          include APort::SDK::Rails::ControllerHelpers
+        end
+      end
+    end
+  end
+end

--- a/sdk/ruby/lib/aport/sdk/version.rb
+++ b/sdk/ruby/lib/aport/sdk/version.rb
@@ -1,0 +1,5 @@
+module APort
+  module SDK
+    VERSION = "0.1.0"
+  end
+end

--- a/sdk/ruby/lib/aporthq_sdk_ruby.rb
+++ b/sdk/ruby/lib/aporthq_sdk_ruby.rb
@@ -1,0 +1,1 @@
+require "aport/sdk"

--- a/sdk/ruby/lib/generators/aport/install/install_generator.rb
+++ b/sdk/ruby/lib/generators/aport/install/install_generator.rb
@@ -1,0 +1,27 @@
+require "rails/generators"
+
+module Aport
+  module Generators
+    class InstallGenerator < Rails::Generators::Base
+      desc "Creates an APort initializer for Rails applications"
+
+      def create_initializer
+        create_file "config/initializers/aport.rb", <<~RUBY
+          require "aport/sdk"
+
+          APort::SDK.configure do |config|
+            config.base_url = ENV.fetch("AGENT_PASSPORT_BASE_URL", "https://api.aport.io")
+            config.api_key = ENV["AGENT_PASSPORT_API_KEY"]
+            config.timeout = 0.8
+          end
+
+          # Protect all routes with a policy:
+          # Rails.application.config.middleware.use(
+          #   APort::SDK::Middleware,
+          #   policy_id: "finance.payment.refund.v1"
+          # )
+        RUBY
+      end
+    end
+  end
+end

--- a/sdk/ruby/test/client_test.rb
+++ b/sdk/ruby/test/client_test.rb
@@ -1,0 +1,106 @@
+require "test_helper"
+require "webrick"
+
+class APortClientTest < Minitest::Test
+  def with_server(&block)
+    requests = []
+    server = WEBrick::HTTPServer.new(
+      Port: 0,
+      Logger: WEBrick::Log.new(File::NULL),
+      AccessLog: []
+    )
+    handler = nil
+    server.mount_proc("/") do |request, response|
+      requests << request
+      handler.call(request, response)
+    end
+
+    thread = Thread.new { server.start }
+    base_url = "http://127.0.0.1:#{server.config[:Port]}"
+    sleep 0.01 until server.status == :Running
+    block.call(base_url, requests, proc { |&new_handler| handler = new_handler })
+  ensure
+    server.shutdown if server
+    thread.join if thread
+  end
+
+  def test_verify_policy_builds_request_and_returns_decision
+    with_server do |base_url, requests, on_request|
+      on_request.call do |request, response|
+        assert_equal "/api/verify/policy/finance.payment.refund.v1", request.path
+        assert_equal "Bearer test-key", request["authorization"]
+        assert_equal "idem-1", request["idempotency-key"]
+
+        body = JSON.parse(request.body)
+        assert_equal "agent_123", body.dig("context", "agent_id")
+        assert_equal "finance.payment.refund.v1", body.dig("context", "policy_id")
+        assert_equal 1000, body.dig("context", "amount")
+
+        response["server-timing"] = "app;dur=9"
+        response.body = JSON.generate("decision" => { "decision_id" => "dec_123", "allow" => true })
+      end
+
+      client = APort::SDK::Client.new(base_url: base_url, api_key: "test-key")
+      decision = client.verify_policy(
+        agent_id: "agent_123",
+        policy_id: "finance.payment.refund.v1",
+        context: { amount: 1000 },
+        idempotency_key: "idem-1"
+      )
+
+      assert_equal 1, requests.length
+      assert_equal true, decision["allow"]
+      assert_equal "dec_123", decision["decision_id"]
+      assert_equal "app;dur=9", decision.dig("_meta", "serverTiming")
+    end
+  end
+
+  def test_api_error_preserves_reasons
+    with_server do |base_url, _requests, on_request|
+      on_request.call do |_request, response|
+        response.status = 403
+        response.body = JSON.generate(
+          "decision_id" => "dec_deny",
+          "reasons" => [{ "code" => "DENIED", "message" => "not allowed" }]
+        )
+      end
+
+      client = APort::SDK::Client.new(base_url: base_url)
+      error = assert_raises(APort::SDK::Error) do
+        client.verify_policy(agent_id: "agent_123", policy_id: "finance.payment.refund.v1")
+      end
+
+      assert_equal 403, error.status
+      assert_equal "dec_deny", error.decision_id
+      assert_equal "DENIED", error.reasons.first["code"]
+    end
+  end
+
+  def test_decision_token_and_jwks_cache
+    jwks_calls = 0
+    with_server do |base_url, _requests, on_request|
+      on_request.call do |request, response|
+        case request.path
+        when "/api/verify/token/finance.payment.refund.v1"
+          response.body = JSON.generate("token" => "token-123")
+        when "/api/verify/token/validate"
+          response.body = JSON.generate("decision" => { "decision_id" => "dec_token", "allow" => true })
+        when "/jwks.json"
+          jwks_calls += 1
+          response.body = JSON.generate("keys" => [{ "kty" => "RSA", "kid" => "kid-1" }])
+        else
+          response.status = 404
+        end
+      end
+
+      client = APort::SDK::Client.new(base_url: base_url)
+      token = client.get_decision_token(agent_id: "agent_123", policy_id: "finance.payment.refund.v1")
+      assert_equal "token-123", token
+
+      2.times do
+        assert_equal true, client.validate_decision_token_local(token: token)["allow"]
+      end
+      assert_equal 1, jwks_calls
+    end
+  end
+end

--- a/sdk/ruby/test/middleware_test.rb
+++ b/sdk/ruby/test/middleware_test.rb
@@ -1,0 +1,78 @@
+require "test_helper"
+require "stringio"
+
+class APortMiddlewareTest < Minitest::Test
+  class FakeClient
+    attr_reader :agent_id, :policy_id, :context
+
+    def initialize(decision)
+      @decision = decision
+    end
+
+    def verify_policy(agent_id:, policy_id:, context:, idempotency_key: nil)
+      @agent_id = agent_id
+      @policy_id = policy_id
+      @context = context
+      @decision
+    end
+
+    def verify_policy_with_passport(passport:, policy_id:, context:, idempotency_key: nil)
+      verify_policy(agent_id: passport.fetch("agent_id"), policy_id: policy_id, context: context, idempotency_key: idempotency_key)
+    end
+
+    def verify_policy_with_policy_in_body(agent_or_passport:, policy:, context:, idempotency_key: nil)
+      agent_id = agent_or_passport.is_a?(Hash) ? agent_or_passport.fetch("agent_id") : agent_or_passport
+      verify_policy(agent_id: agent_id, policy_id: policy.fetch("id"), context: context, idempotency_key: idempotency_key)
+    end
+  end
+
+  def test_allows_request_and_sets_env
+    client = FakeClient.new("decision_id" => "dec_1", "allow" => true)
+    app = lambda do |env|
+      [200, { "Content-Type" => "application/json" }, [JSON.generate("agent_id" => env["aport.agent_id"], "decision_id" => env["aport.decision"]["decision_id"])]]
+    end
+    middleware = APort::SDK::Middleware.new(app, client: client, policy_id: "finance.payment.refund.v1")
+
+    status, _headers, body = middleware.call(env("X-Agent-Passport-Id" => "agent_123", body: { amount: 20 }))
+
+    assert_equal 200, status
+    assert_includes body.join, "dec_1"
+    assert_equal "agent_123", client.agent_id
+    assert_equal "finance.payment.refund.v1", client.policy_id
+    assert_equal 20, client.context["amount"]
+  end
+
+  def test_denies_policy_violation
+    client = FakeClient.new("decision_id" => "dec_deny", "allow" => false, "reasons" => [{ "code" => "DENIED" }])
+    middleware = APort::SDK::Middleware.new(lambda { |_env| [200, {}, ["ok"]] }, client: client, policy_id: "finance.payment.refund.v1")
+
+    status, _headers, body = middleware.call(env("X-Agent-Id" => "agent_123"))
+
+    assert_equal 403, status
+    assert_includes body.join, "policy_violation"
+    assert_includes body.join, "dec_deny"
+  end
+
+  def test_missing_agent_fails_closed
+    client = FakeClient.new("decision_id" => "dec_1", "allow" => true)
+    middleware = APort::SDK::Middleware.new(lambda { |_env| [200, {}, ["ok"]] }, client: client, policy_id: "finance.payment.refund.v1")
+
+    status, _headers, body = middleware.call(env)
+
+    assert_equal 401, status
+    assert_includes body.join, "missing_agent_id"
+  end
+
+  private
+
+  def env(headers = {})
+    body_hash = headers.delete(:body) || {}
+    raw_body = body_hash.empty? ? "" : JSON.generate(body_hash)
+    {
+      "PATH_INFO" => "/refunds",
+      "REQUEST_PATH" => "/refunds",
+      "CONTENT_TYPE" => raw_body.empty? ? nil : "application/json",
+      "rack.input" => StringIO.new(raw_body)
+    }.merge(headers.transform_keys { |key| "HTTP_#{key.upcase.tr("-", "_")}" })
+  end
+end

--- a/sdk/ruby/test/test_helper.rb
+++ b/sdk/ruby/test/test_helper.rb
@@ -1,0 +1,6 @@
+$LOAD_PATH.unshift File.expand_path("../lib", __dir__)
+
+$VERBOSE = nil
+
+require "minitest/autorun"
+require "aport/sdk"


### PR DESCRIPTION
Closes https://github.com/aporthq/aport-integrations/issues/16

## Summary
- add `aporthq-sdk-ruby` with a thin APort API client, structured errors, policy helpers, decision tokens, passport views, and JWKS caching
- add Rack/Rails middleware, controller helpers, and a Rails install generator
- add package docs and repository README entries for Ruby/Rails usage

## Verification
- `ruby -Ilib -Itest test/client_test.rb test/middleware_test.rb`
- `rake test`
- `find sdk/ruby -name '*.rb' -print0 | xargs -0 -n1 ruby -c`
- `gem build aporthq-sdk-ruby.gemspec --output /private/tmp/aporthq-sdk-ruby-0.1.0.gem`
- `git diff --check`

Bounty payout BTC address: `39Q34P8A7g375yqEr8buvNJkUbRgKfbKQZ`